### PR TITLE
Timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 *.asv
 *~
+*.tmp
 
 # Python optimization leftovers
 __pycache__/
@@ -16,6 +17,7 @@ __pycache__/
 # Subject data
 *.edf
 /beh/*.txt
+/beh/*.tsv
 
 # Stimuli
 *.mov

--- a/Analysis/debugFrameTime.m
+++ b/Analysis/debugFrameTime.m
@@ -1,9 +1,9 @@
-% It looks like the videos are shooting for a frame rate of 60 fps
-% So the expected duration is 0.0167 sec or 16.7 msec
-% But the measured duration of each 'frame' is closer to 0.669 msec,
-% Which means PTB is trying to refresh at a rate closer to 1000 fps
-% So this analysis is a bust.
-% I have no idea whether timing is significantly degraded or not.
+% Reads in ANY .tsv file in beh/ with 'task-debug' in the filename
+% Expects to see a column called 'Onset' for each frame of each video
+% Calculates frame duration based on onset times, 
+% then generates a histogram 
+
+% 
 
 pths = specifyPaths('..');
 % pths.beh = pwd;
@@ -17,33 +17,33 @@ for i = 1:numFiles
     numStims = length(stimList);
     output(i).name = fname;
     output(i).numStims = numStims;
-    figure();
+    flatOutput = [];
     for o = 1:numStims
-        output(i).stim(o).name = stimList(i);
+        output(i).stim(o).name = stimList(o);
         % We're dealing with onset times, but we care about durations
         % So use diff to get the differences b/w onset times, 
         % which is essentially the same thing as duration
         % Produces n-1 results since we don't get an offset for the final
-        output(i).stim(o).data = diff(input.Onset(strcmp(input.StimName,stimList(i))));
-
+        output(i).stim(o).data = diff(input.Onset(strcmp(input.StimName,stimList(o))));
+        flatOutput = [flatOutput; output(i).stim(o).data];
         % Subplot histograms for every movie
-        subplot(1,numStims,o);
+        figure();
             histogram(output(i).stim(o).data * 1000);
-            title(stimList(i));
+            title(strrep(stimList(o),'_','\_'));
             xlabel('Frame duration (msec)');
             ylabel('Num instances');
-            xlim([.5,1]); % fine-tune
+            xlim([0,36]); % fine-tune
             % ylim([0,100]); % fine-tune
     end
     % Separate by movie
     % data = pivot(input, Columns='StimName', Method="mean", DataVariable='Duration')
     % Plot histogram of frame durations
     figure()
-        histogram(input.Duration * 1000);
+        histogram(flatOutput * 1000);
         title(sprintf('Considering %i movies', numStims));
         xlabel('Frame duration (msec)');
         ylabel('Num instances');
-        xlim([.5,1]); % fine-tune
+        xlim([0,36]); % fine-tune
     
     % t-test for differences by movie?
 end

--- a/Analysis/debugFrameTime.m
+++ b/Analysis/debugFrameTime.m
@@ -20,7 +20,11 @@ for i = 1:numFiles
     figure();
     for o = 1:numStims
         output(i).stim(o).name = stimList(i);
-        output(i).stim(o).data = input.Duration(strcmp(input.StimName,stimList(i)));
+        % We're dealing with onset times, but we care about durations
+        % So use diff to get the differences b/w onset times, 
+        % which is essentially the same thing as duration
+        % Produces n-1 results since we don't get an offset for the final
+        output(i).stim(o).data = diff(input.Onset(strcmp(input.StimName,stimList(i))));
 
         % Subplot histograms for every movie
         subplot(1,numStims,o);

--- a/Analysis/debugFrameTime.m
+++ b/Analysis/debugFrameTime.m
@@ -1,6 +1,10 @@
-% trial number
-% stimulus ID
-% timestamp of frame onset
+% It looks like the videos are shooting for a frame rate of 60 fps
+% So the expected duration is 0.0167 sec or 16.7 msec
+% But the measured duration of each 'frame' is closer to 0.669 msec,
+% Which means PTB is trying to refresh at a rate closer to 1000 fps
+% So this analysis is a bust.
+% I have no idea whether timing is significantly degraded or not.
+
 pths = specifyPaths('..');
 % pths.beh = pwd;
 flist = dir(fullfile(pths.beh, '*_task-debug_date-*.tsv'));
@@ -20,22 +24,22 @@ for i = 1:numFiles
 
         % Subplot histograms for every movie
         subplot(1,numStims,o);
-            histogram(output(i).stim(o).data);
+            histogram(output(i).stim(o).data * 1000);
             title(stimList(i));
-            xlabel('Frame duration (sec)');
+            xlabel('Frame duration (msec)');
             ylabel('Num instances');
-            % xlim([20,40]); % fine-tune
+            xlim([.5,1]); % fine-tune
             % ylim([0,100]); % fine-tune
     end
     % Separate by movie
     % data = pivot(input, Columns='StimName', Method="mean", DataVariable='Duration')
     % Plot histogram of frame durations
     figure()
-        histogram(input.Duration);
+        histogram(input.Duration * 1000);
         title(sprintf('Considering %i movies', numStims));
-        xlabel('Frame duration (sec)');
+        xlabel('Frame duration (msec)');
         ylabel('Num instances');
-
+        xlim([.5,1]); % fine-tune
     
     % t-test for differences by movie?
 end

--- a/Analysis/debugFrameTime.m
+++ b/Analysis/debugFrameTime.m
@@ -1,8 +1,8 @@
 % trial number
 % stimulus ID
 % timestamp of frame onset
-% pths = specifyPaths('..');
-pths.beh = pwd;
+pths = specifyPaths('..');
+% pths.beh = pwd;
 flist = dir(fullfile(pths.beh, '*_task-debug_date-*.tsv'));
 numFiles = length(flist);
 for i = 1:numFiles

--- a/Analysis/debugFrameTime.m
+++ b/Analysis/debugFrameTime.m
@@ -1,18 +1,41 @@
 % trial number
 % stimulus ID
 % timestamp of frame onset
-pths = specifyPaths('..');
+% pths = specifyPaths('..');
+pths.beh = pwd;
 flist = dir(fullfile(pths.beh, '*_task-debug_date-*.tsv'));
 numFiles = length(flist);
 for i = 1:numFiles
-    fname = fullfile(pths.specifyPaths, flist(i).Name);
-    input = readtable(fname);
+    fname = fullfile(pths.beh, flist(i).name);
+    input = readtable(fname, "FileType","text",'Delimiter', '\t');
     % 'Trial \tStimName \tFrame \tDuration\n'
     stimList = unique(input.StimName);
     numStims = length(stimList);
+    output(i).name = fname;
+    output(i).numStims = numStims;
+    figure();
+    for o = 1:numStims
+        output(i).stim(o).name = stimList(i);
+        output(i).stim(o).data = input.Duration(strcmp(input.StimName,stimList(i)));
+
+        % Subplot histograms for every movie
+        subplot(1,numStims,o);
+            histogram(output(i).stim(o).data);
+            title(stimList(i));
+            xlabel('Frame duration (sec)');
+            ylabel('Num instances');
+            % xlim([20,40]); % fine-tune
+            % ylim([0,100]); % fine-tune
+    end
     % Separate by movie
-    data = pivot(input, Columns='StimName', DataVariable='Duration')
+    % data = pivot(input, Columns='StimName', Method="mean", DataVariable='Duration')
     % Plot histogram of frame durations
+    figure()
+        histogram(input.Duration);
+        title(sprintf('Considering %i movies', numStims));
+        xlabel('Frame duration (sec)');
+        ylabel('Num instances');
+
     
     % t-test for differences by movie?
 end

--- a/Analysis/debugFrameTime.m
+++ b/Analysis/debugFrameTime.m
@@ -1,0 +1,18 @@
+% trial number
+% stimulus ID
+% timestamp of frame onset
+pths = specifyPaths('..');
+flist = dir(fullfile(pths.beh, '*_task-debug_date-*.tsv'));
+numFiles = length(flist);
+for i = 1:numFiles
+    fname = fullfile(pths.specifyPaths, flist(i).Name);
+    input = readtable(fname);
+    % 'Trial \tStimName \tFrame \tDuration\n'
+    stimList = unique(input.StimName);
+    numStims = length(stimList);
+    % Separate by movie
+    data = pivot(input, Columns='StimName', DataVariable='Duration')
+    % Plot histogram of frame durations
+    
+    % t-test for differences by movie?
+end

--- a/Analysis/simulateData.m
+++ b/Analysis/simulateData.m
@@ -1,0 +1,23 @@
+% Parameters to recover
+mu = 24; sigma = .3;
+
+% Open output file
+outputPath = fullfile(pwd, 'sub-01_task-debug_date-22-Jan-2024.tsv');
+fid = fopen(outputPath, 'a');
+fprintf(fid, 'Trial \tStimName \tFrame \tDuration\n'); % write header
+
+numSims = 4;
+duration = 15; % seconds, say
+numFrames = duration * mu;
+
+for s = 1:numSims
+    simName = sprintf('%2.f_fakeMovie_frameRate-%i.mov', s, mu);
+    simData = (sigma * randn([numFrames, 1])) + mu; % simulate new data per run
+    for f = 1:numFrames
+        % output simulated data
+        fprintf(fid, '%i\t%s\t%i\t%4.6f\n', s, simName, f, simData(f));
+    end
+    simData = []; % clear before recalculating, just to be careful
+end
+fclose(fid);
+fprintf(1, 'Simulated data exported to %s\n', outputPath);

--- a/Main_EyeLink.m
+++ b/Main_EyeLink.m
@@ -235,11 +235,11 @@ try
 
     % Set up a trial-level output file, for debugging timing info
     fOut2 = strcat(subID, '_task-debug_date-', datestr(now, 1));
-    fOut2 = fullfile(pths.beh, [fOut2 '.txt']);
+    fOut2 = fullfile(pths.beh, [fOut2 '.tsv']);
     fid2 = fopen(fOut2, 'a');
     fprintf(fid2, '%s\n', fOut2);
     fprintf(fid2, '%s\n', datestr(now));
-    fprintf(fid2, 'Trial \tStimName \tFrame \tOnset\n');
+    fprintf(fid2, 'Trial \tStimName \tFrame \tDuration\n');
     
     % Some response keys
     spaceBar = KbName('space');% Identify keyboard key code for space bar to end each trial later on    
@@ -352,7 +352,7 @@ try
             % Draw the new texture immediately to screen:
             Screen('DrawTexture', window, tex);            
             % Update display:
-            frameTime = Screen('Flip', window);
+            frameOn = Screen('Flip', window);
             frameNum = frameNum + 1;
             if frameNum == 1
                 % Write message to EDF file to mark the start time of stimulus presentation.
@@ -366,10 +366,6 @@ try
             Eyelink('Message', 'Frame to be displayed %d', frameNum);
             % Write a !V VFRAME message to the data file specifying the frame number, location and file name so DataViewer can play back the video
             Eyelink('Message', '%d !V VFRAME %d %d %d %s', 0, frameNum, round(width/2-Movx/2), round(height/2-Movy/2), movieName);
-            
-            % Output debug data
-            % 'Trial \tStimName \tFrame \tOnset\n'
-            fprintf(fid2, '%i\t%s\t%i\t%4.6f\n', i, movieName, frameNum, frameTime - ExptStart);
 
             % End trial if space bar is pressed
             [~, kbSecs, keyCode] = KbCheck;
@@ -387,6 +383,12 @@ try
                 break;
             end
             Screen('Close', tex); % Release texture if no key is pressed
+            
+            % Output debug data
+            % 'Trial \tStimName \tFrame \tOnset\n'
+            frameOff = GetSecs; % because Screen('Close') doesn't have an output
+            fprintf(fid2, '%i\t%s\t%i\t%4.6f\n', i, movieName, frameNum, frameOff - frameOn);
+
         end  % End while loop
         Screen('PlayMovie', movie, 0); % Stop playback
         Screen('CloseMovie', movie); % Close movie

--- a/Main_EyeLink.m
+++ b/Main_EyeLink.m
@@ -157,7 +157,7 @@ try
         Screen('Preference', 'SkipSyncTests',0); % allow test for real run
     end
     
-%     Screen('Preference', 'SkipSyncTests', 1); 
+    Screen('Preference', 'SkipSyncTests', 1); 
     window = Screen('OpenWindow', screenNumber, [128 128 128]); % Open graphics window
     Screen('Flip', window);
     % Return width and height of the graphics window/screen in pixels

--- a/Main_EyeLink.m
+++ b/Main_EyeLink.m
@@ -240,7 +240,7 @@ try
     fid2 = fopen(fOut2, 'a');
     fprintf(fid2, '%s\n', fOut2);
     fprintf(fid2, '%s\n', datestr(now));
-    fprintf(fid2, 'Trial \tStimName \tFrame \tDuration\n');
+    fprintf(fid2, 'Trial \tStimName \tFrame \tOnset\n');
     
     % Some response keys
     spaceBar = KbName('space');% Identify keyboard key code for space bar to end each trial later on    
@@ -387,8 +387,7 @@ try
             
             % Output debug data
             % 'Trial \tStimName \tFrame \tOnset\n'
-            frameOff = GetSecs; % because Screen('Close') doesn't have an output
-            fprintf(fid2, '%i\t%s\t%i\t%4.6f\n', i, movieName, frameNum, frameOff - frameOn);
+            fprintf(fid2, '%i\t%s\t%i\t%4.6f\n', i, movieName, frameNum, frameOn - vidStart);
 
         end  % End while loop
         Screen('PlayMovie', movie, 0); % Stop playback

--- a/Main_EyeLink.m
+++ b/Main_EyeLink.m
@@ -232,6 +232,14 @@ try
     fprintf(fid, '%s\n', fOutBase);
     fprintf(fid, '%s\n', datestr(now));
     fprintf(fid, 'Trial \tResponse \tRT \tTime \tStimName\n');
+
+    % Set up a trial-level output file, for debugging timing info
+    fOut2 = strcat(subID, '_task-debug_date-', datestr(now, 1));
+    fOut2 = fullfile(pths.beh, [fOut2 '.txt']);
+    fid2 = fopen(fOut2, 'a');
+    fprintf(fid2, '%s\n', fOut2);
+    fprintf(fid2, '%s\n', datestr(now));
+    fprintf(fid2, 'Trial \tStimName \tFrame \tOnset\n');
     
     % Some response keys
     spaceBar = KbName('space');% Identify keyboard key code for space bar to end each trial later on    
@@ -344,7 +352,7 @@ try
             % Draw the new texture immediately to screen:
             Screen('DrawTexture', window, tex);            
             % Update display:
-            Screen('Flip', window);
+            frameTime = Screen('Flip', window);
             frameNum = frameNum + 1;
             if frameNum == 1
                 % Write message to EDF file to mark the start time of stimulus presentation.
@@ -358,6 +366,11 @@ try
             Eyelink('Message', 'Frame to be displayed %d', frameNum);
             % Write a !V VFRAME message to the data file specifying the frame number, location and file name so DataViewer can play back the video
             Eyelink('Message', '%d !V VFRAME %d %d %d %s', 0, frameNum, round(width/2-Movx/2), round(height/2-Movy/2), movieName);
+            
+            % Output debug data
+            % 'Trial \tStimName \tFrame \tOnset\n'
+            fprintf(fid2, '%i\t%s\t%i\t%4.6f\n', i, movieName, frameNum, frameTime - ExptStart);
+
             % End trial if space bar is pressed
             [~, kbSecs, keyCode] = KbCheck;
             if keyCode(spaceBar) || keyCode(deleteKey)
@@ -444,6 +457,7 @@ try
     transferFile; % See transferFile function below    
     
     fclose(fid); % close the behavioral output file
+    fclose(fid2); % close the debug file
 catch % If syntax error is detected
     cleanup;
     % Print error message and line number in Matlab's Command Window


### PR DESCRIPTION
**Accidentally closed without merging - redoing this pull request**

Psychtoolbox complains about MacOS interfering with its ability to display things on screen with accurate timing, and refuses to continue unless you skip some internal tests. This is a problem because we fully intend to run this experiment on a Mac. Thus, we ought to see see how much that really matters. Comes now this `timing` branch, which adds some tests to analyze video timing when PTB's synchronization tests are bypassed.

Results after one run of n=30 videos are that all videos stay close to the target framerate of 60 fps or 16.67 msec/frame, but there is a distribution around that target (mean = 16.917, std = 2.045). The mean is pulled to the right by a small cluster of anomalously large frame durations: about 1.45% of frames form a distribution around 33.18 msec (std = 1.40), which is closer to 30 fps than 60. If we exclude those outlier frames, the main distribution is (mean = 16.677 msec, std = 0.51 msec). See Fig. 1 below.

All that is to say that about 99% of the time, things are happening exactly as they should, but 1% of the time, *in each video*, the framerate drops from 60fps to 30fps. This does not happen at a regular time, e.g. always the first or final frame, but seems to happen randomly - as likely to be 30% to 75% into the video duration as it is the very beginning or end. 

It remains unclear whether this is problematic or not for this project. We send the eyetracker a timestamp of every frame's onset, so even if the video is not necessarily stable during presentation, eyetracking data should be synced to that instability. We also now output the frame durations to a file per subject (labelled as `task-debug`) so we know exactly when and where frame instability happens and have the ability to reject trials *post-hoc* based on that information. 

Qualitatively, though, I didn't notice anything wrong with the videos when watching. They're so sparsely animated that it's likely not much of a factor - it may even be a deliberate attempt by the video engine to save bandwidth when there is no action on screen. I could keep analyzing, but it seems to be much ado about nothing.

**Current directive is to soldier on.**


**Fig. 1** Histogram of frame durations 
![Screen Shot 2024-01-23 at 12 58 49 PM](https://github.com/VPNLirvine/trEYEcopa/assets/147678187/c2167601-7dd6-4578-aaf6-edfb062b1579)
*Note.* The target duration is 16.67msec or 60Hz. The vast majority of frames are reasonably close to this value, but a small subset (~1%) are at the wildly different 30 fps.
