### PR TITLE
Take a break

### DIFF
--- a/Main_EyeLink.m
+++ b/Main_EyeLink.m
@@ -585,14 +585,14 @@ end
         % Set a ratio of trials to take a break on
         ratio = 1/3;
         maxBreak = 60; % seconds
-
+        
         % Determine whether this trial qualifies
-        if trial == floor(maxTrials * ratio) + 1
+        if ~rem(trial, floor(maxTrials * ratio) + 1)
             % Interrupt the experiment for up to a minute
-            bText = sprintf(['You have completed %i of %i trials!\n...' ...
-                'Take a minute to relax your eyes.\n\n...' ...
-                'Press the spacebar when you''re ready to continue'], ...
-                trial, maxTrials);
+            bText = sprintf(['You have completed %i of %i trials!\n' ...
+                'Take a minute to relax your eyes.\n\n' ...
+                'Press the spacebar when you are ready to continue'], ...
+                trial-1, maxTrials);
             Screen('FillRect', window, ScreenBkgd, wRect); % fill bkgd with mid-gray
             DrawFormattedText(window, bText, 'center', 'center', TextColor);
             

--- a/Main_EyeLink.m
+++ b/Main_EyeLink.m
@@ -229,7 +229,7 @@ try
     [~,taskID] = fileparts(stimPath);
     fOutBase = strcat(subID, '_task-', taskID, '_date-', datestr(now, 1));
     fNameOut = fullfile(pths.beh, strcat(fOutBase, '.txt'));
-    fid = fopen(fNameOut, 'a');
+    fid = fopen(fNameOut, 'w+');
     if fid == -1, fprintf(1, 'ALERT!!! Output file did not open properly.\n'); sysbeep; end
 
     fprintf(fid, '%s\n', fOutBase);
@@ -239,7 +239,7 @@ try
     % Set up a trial-level output file, for debugging timing info
     fOut2 = strcat(subID, '_task-debug_date-', datestr(now, 1));
     fOut2 = fullfile(pths.beh, [fOut2 '.tsv']);
-    fid2 = fopen(fOut2, 'a');
+    fid2 = fopen(fOut2, 'w+');
     fprintf(fid2, '%s\n', fOut2);
     fprintf(fid2, '%s\n', datestr(now));
     fprintf(fid2, 'Trial \tStimName \tFrame \tOnset\n');


### PR DESCRIPTION
Sets a ratio of trials on which to enforce a one-minute-max break, because the experiment is kind of long. Addresses issue #21 

...also changes the behavior of the output files from appending to overwriting. Now you never get an unreadable file, but you also run the risk of overwriting previous data. But considering the EDF files overwrite anyway, at least now it's consistent.