### PR TITLE
Hotfix6

### DIFF
--- a/Analysis/convertUTF16toUTF8.m
+++ b/Analysis/convertUTF16toUTF8.m
@@ -1,0 +1,17 @@
+function convertUTF16toUTF8(inputFile, outputFile)
+    % Check if the input file exists
+    if exist(inputFile, 'file') ~= 2
+        error('Input file does not exist.');
+    end
+    
+    % Convert UTF-16 to UTF-8 using iconv
+    command = sprintf('iconv -f UTF-16 -t UTF-8 "%s" > "%s"', inputFile, outputFile);
+    [status, ~] = system(command);
+    
+    % Check if the conversion was successful
+    if status ~= 0
+        error('Error occurred during UTF-16 to UTF-8 conversion.');
+    else
+        disp('File converted successfully.');
+    end
+end

--- a/Analysis/getAQ.m
+++ b/Analysis/getAQ.m
@@ -12,9 +12,11 @@ fname = fullfile(pths.beh, x(1).name);
 % Qualtrics spits out data in UTF-16 format
 % Matlab versions previous to ~2022 do not support this format
 % Convert to UTF-8 instead, for compatibility
-convertUTF16toUTF8(fname, fname);
+fname = verifyEncoding(fname);
+
 % Now finally read the data in
-data = readtable(fname, "FileType", "text", "Delimiter", "\t");
+opts = detectImportOptions(fname, "FileType", "text", "Delimiter", "\t");
+data = readtable(fname, opts);
 
 % Set up export variable
 output = table();

--- a/Analysis/getAQ.m
+++ b/Analysis/getAQ.m
@@ -9,7 +9,12 @@ warning('off', 'MATLAB:textio:io:UnableToGuessFormat'); % don't care about dates
 % Import AQ data from Qualtrics
 x = dir(fullfile(pths.beh,'Baron Cohen*.tsv'));
 fname = fullfile(pths.beh, x(1).name);
-data = readtable(fname, "FileType", "delimitedtext", "Delimiter", "\t");
+% Qualtrics spits out data in UTF-16 format
+% Matlab versions previous to ~2022 do not support this format
+% Convert to UTF-8 instead, for compatibility
+convertUTF16toUTF8(fname, fname);
+% Now finally read the data in
+data = readtable(fname, "FileType", "text", "Delimiter", "\t");
 
 % Set up export variable
 output = table();

--- a/Analysis/verifyEncoding.m
+++ b/Analysis/verifyEncoding.m
@@ -1,0 +1,28 @@
+function fname2 = verifyEncoding(fname)
+% Ensure this file can be read by MATLAB
+% Matlab 2019a can't read UTF-16, but it CAN read UTF-8
+% So this checks the encoding of your input file and converts if necessary.
+
+% First, see if this script has been run before
+% If so, just export the name of the converted file.
+fname2 = replace(fname, '.tsv', '_utf8.tsv');
+
+if ~exist(fname2, 'file')
+    % Perform conversion.
+    % Read in file as byte numbers
+    fid = fopen(fname, 'r');
+    txt = fread(fid);
+    fclose(fid);
+
+    % Check that the "byte order" is [255 254] or [254 255]
+    border = txt(1:2);
+    % If so, it is UTF-16, so convert it.
+    % If not, don't convert it, bc that will result in an empty file.
+    if isequal(border,[255; 254]) || isequal(border, [254; 255])
+        convertUTF16toUTF8(fname, fname2);
+    else
+        fname2 = fname;
+        warning('Could not detect encoding scheme for file %s.\nAssuming it''s fine.', fname);
+    end
+
+end


### PR DESCRIPTION
Enable compatibility with older Matlab versions by converting the UTF16-encoded Qualtrics data to UTF8 encoding.