### PR TITLE
QC update 3

### DIFF
--- a/Analysis/QC_duration.m
+++ b/Analysis/QC_duration.m
@@ -21,19 +21,19 @@ exe = sprintf("mdls %s | grep Duration | awk '{ print $3 }'", fname);
 exptDur = str2double(exptDur);
 
 %% Estimate the duration of the video from the EDF data
-dur1 = edf.Header.duration; % Header duration
-dur2 = edf.Header.endtime - edf.Header.starttime; % Header difference
-dur3 = edf.Header.endtime - edf.StartTime; % osfImport duration
-sr = edf.Header.rec.sample_rate;
-sr2 = 250; % I think the above defaults to 500, even though we do 250
+dur1 = double(edf.Header.duration); % Header duration
+dur2 = double(edf.Header.endtime - edf.Header.starttime); % Header difference
+dur3 = double(edf.Header.endtime - edf.StartTime); % osfImport duration
+dur4 = getStimDuration(edf); % PTB presentation time in seconds
+dur5 = double(edf.Samples.time(end) - edf.Samples.time(1)); % Length of eyetracking in ms
+dur6 = findStimOffset(edf) - findStimOnset(edf);
 
 %% Compare all three EDF durations to the expected duration
 fprintf(1, '\nVideo: %s\n', stimName);
 fprintf(1, 'Expected duration is %0.4f sec\n', exptDur);
-fprintf(1, '\tHeader duration at %i Hz is %0.4f sec\n', sr, dur1 / sr);
-fprintf(1, '\tCalculated duration at %i Hz is %0.4f sec\n', sr, dur2 / sr);
-fprintf(1, '\tosfImport duration at %i Hz is %0.4f sec\n', sr, dur3 / sr);
-fprintf(1, '\n');
-fprintf(1, '\tHeader duration at %i Hz is %0.4f sec\n', sr2, dur1 / sr2);
-fprintf(1, '\tCalculated duration at %i Hz is %0.4f sec\n', sr2, dur2 / sr2);
-fprintf(1, '\tosfImport duration at %i Hz is %0.4f sec\n', sr2, dur3 / sr2);
+fprintf(1, '\tEDF Header duration is %0.4f sec\n', dur1 / 1000);
+fprintf(1, '\tCalculated duration is %0.4f sec\n', dur2 / 1000);
+fprintf(1, '\tosfImport-based duration is %0.4f sec\n', dur3 / 1000);
+fprintf(1, '\tMessage-based duration is %0.4f sec\n', dur4);
+fprintf(1, '\tSampling duration is %0.4f sec\n', dur5 / 1000);
+fprintf(1, '\tPrecise video duration is %0.4f sec\n', dur6 / 1000);

--- a/Analysis/QC_duration.m
+++ b/Analysis/QC_duration.m
@@ -1,0 +1,39 @@
+function QC_duration(edf)
+% After extracting some edf data into `edf`, analyze the duration info
+% There are three sources of video duration, and all seem unreliable
+% The sample rate that is given for each trial also seems unreliable
+% Investigate.
+
+stimName = getStimName(edf);
+%% Get the expected duration of the video
+% Get file location
+pths = specifyPaths('..');
+fname = fullfile(pths.TCstim, stimName);
+
+% % Read the expected duration of the video
+% vidHeader = mmfileinfo(fname);
+% exptDur = vidHeader.Duration;
+%
+% Use a Mac built-in function to find video duration
+% Do this instead of mmfileinfo() bc I get a codec error on my laptop
+exe = sprintf("mdls %s | grep Duration | awk '{ print $3 }'", fname);
+[~,exptDur] = system(exe);
+exptDur = str2double(exptDur);
+
+%% Estimate the duration of the video from the EDF data
+dur1 = edf.Header.duration; % Header duration
+dur2 = edf.Header.endtime - edf.Header.starttime; % Header difference
+dur3 = edf.Header.endtime - edf.StartTime; % osfImport duration
+sr = edf.Header.rec.sample_rate;
+sr2 = 250; % I think the above defaults to 500, even though we do 250
+
+%% Compare all three EDF durations to the expected duration
+fprintf(1, '\nVideo: %s\n', stimName);
+fprintf(1, 'Expected duration is %0.4f sec\n', exptDur);
+fprintf(1, '\tHeader duration at %i Hz is %0.4f sec\n', sr, dur1 / sr);
+fprintf(1, '\tCalculated duration at %i Hz is %0.4f sec\n', sr, dur2 / sr);
+fprintf(1, '\tosfImport duration at %i Hz is %0.4f sec\n', sr, dur3 / sr);
+fprintf(1, '\n');
+fprintf(1, '\tHeader duration at %i Hz is %0.4f sec\n', sr2, dur1 / sr2);
+fprintf(1, '\tCalculated duration at %i Hz is %0.4f sec\n', sr2, dur2 / sr2);
+fprintf(1, '\tosfImport duration at %i Hz is %0.4f sec\n', sr2, dur3 / sr2);

--- a/Analysis/findStimOffset.m
+++ b/Analysis/findStimOffset.m
@@ -1,0 +1,11 @@
+function onTime = findStimOffset(edfRow)
+% The other onset times are all wrong
+% The one in the header includes the duration of the drift check(s)
+% The one from osfImport includes a few samples before video onset
+% This tells you exactly when (in eyetracker units) the video starts
+
+list = edfRow.Events.message;
+chktxt = 'BLANK_SCREEN';
+y = cellfun(@(x) contains(x, chktxt), list);
+assert(sum(y) > 0, 'No message re stimulus offset found!');
+onTime = double(edfRow.Events.sttime(y));

--- a/Analysis/findStimOnset.m
+++ b/Analysis/findStimOnset.m
@@ -1,0 +1,11 @@
+function onTime = findStimOnset(edfRow)
+% The other onset times are all wrong
+% The one in the header includes the duration of the drift check(s)
+% The one from osfImport includes a few samples before video onset
+% This tells you exactly when (in eyetracker units) the video starts
+
+list = edfRow.Events.message;
+chktxt = 'STIM_ONSET';
+y = cellfun(@(x) contains(x, chktxt), list);
+assert(sum(y) > 0, 'No message re stimulus onset found!');
+onTime = double(edfRow.Events.sttime(y));

--- a/Analysis/getGraphLabel.m
+++ b/Analysis/getGraphLabel.m
@@ -16,6 +16,11 @@ switch metricName
         txt = 'Percent time spent fixating';
         hy = [0 100];
         yl = [0 1.1];
+    case 'duration'
+        txt = 'Duration of stimulus in sec';
+        % Until I discover the range...
+        hy = 'tight';
+        yl = 'tight';
     case 'meanfix'
         txt = 'Average fixation time in ms';
         hy = [0 60];

--- a/Analysis/getGraphLabel.m
+++ b/Analysis/getGraphLabel.m
@@ -24,11 +24,11 @@ switch metricName
     case 'meanfix'
         txt = 'Average fixation time in ms';
         hy = [0 60];
-        yl = [220 1000];
+        yl = [0 2000];
     case 'medianfix'
         txt = 'Median fixation time in ms';
         hy = [0 60];
-        yl = [175 800];
+        yl = [0 1000];
     case 'maxfixOnset'
         txt = 'Onset time of longest fixation';
         hy = [0 45];

--- a/Analysis/getStimDuration.m
+++ b/Analysis/getStimDuration.m
@@ -1,0 +1,18 @@
+function duration = getStimDuration(edfRow)
+% Trial duration in the EDF files is in unknown units,
+% so this function determines length in seconds
+% by finding a message sent by the experiment on stimulus end.
+%
+% Input is a single ROW of the output of osfImport (i.e. not all trials).
+% Output is duration in seconds.
+%
+% If you want to write that value into the edf somewhere, that's up to you.
+
+list = edfRow.Events.message;
+chktxt = '!V TRIAL_VAR video_duration ';
+y = cellfun(@(x) contains(x, chktxt), list);
+assert(sum(y) > 0, 'No message re video duration found!');
+duration = str2double(erase(list{y}, '!V TRIAL_VAR video_duration '));
+duration = duration / 1000; % convert from ms to sec
+
+end

--- a/Analysis/selectMetric.m
+++ b/Analysis/selectMetric.m
@@ -5,7 +5,7 @@ function output = selectMetric(edfDat, metricName, varargin)
 % Options are as follows:
 %   'fixation' - Total fixation time per trial
 %   'scaledfixation' - Percentage of video time spent fixating
-%   'duration' - Duration of the video (a QC metric)
+%   'duration' - Duration of the video  in sec (a QC metric)
 %   'meanfix' - Average fixation duration within a trial
 %   'medianfix' - Median fixation duration within a trial
 %   'maxfixOnset' - Onset time of the longest fixation
@@ -34,16 +34,15 @@ switch metricName
         data = fixOutliers(data); 
         data = sum(data);
         % duration = double(edfDat.Header.duration);
-        duration = double(edfDat.Header.endtime - edfDat.Header.starttime);
+        % duration = double(edfDat.Header.endtime - edfDat.Header.starttime);
+        duration = double(edfDat.Samples.time(end) - edfDat.Samples.time(1));
         % The provided duration value is unreliable:
         % sometimes it's 0, sometimes it's far less than sum(fixations)
         % so just calculate it from start and end time instead.
 
         output = data / duration;
     case 'duration'
-        numSamples = double(edfDat.Header.endtime - edfDat.Header.starttime);
-        sampleRate = double(edfDat.Header.rec.sample_rate);
-        output = numSamples / sampleRate;
+        output = getStimDuration(edfDat);
     case 'meanfix'
         data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
         data = fixOutliers(data);

--- a/Analysis/selectMetric.m
+++ b/Analysis/selectMetric.m
@@ -24,18 +24,23 @@ else
     i = n;
 end
 
+% Find timepoints bounding stimulus presentation
+recStart = findStimOnset(edfDat);
+recEnd = findStimOffset(edfDat);
+
 switch metricName
     case 'fixation'
-        data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
+        data = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         data = fixOutliers(data);
         output = sum(data);
     case 'scaledfixation'
-        data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
-        data = fixOutliers(data); 
+        data = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
+        data = fixOutliers(data);
         data = sum(data);
         % duration = double(edfDat.Header.duration);
         % duration = double(edfDat.Header.endtime - edfDat.Header.starttime);
-        duration = double(edfDat.Samples.time(end) - edfDat.Samples.time(1));
+        % duration = double(edfDat.Samples.time(end) - edfDat.Samples.time(1));
+        duration = recEnd - recStart;
         % The provided duration value is unreliable:
         % sometimes it's 0, sometimes it's far less than sum(fixations)
         % so just calculate it from start and end time instead.
@@ -44,25 +49,25 @@ switch metricName
     case 'duration'
         output = getStimDuration(edfDat);
     case 'meanfix'
-        data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
+        data = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         data = fixOutliers(data);
         output = mean(data);
     case 'medianfix'
-        data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
+        data = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         data = fixOutliers(data);
         output = median(data);
     case 'maxfixOnset'
-        data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
+        data = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         data = fixOutliers(data);
         [~, position] = max(data);
         output = edfDat.Fixations.sttime(:,position);
     case 'minfixOnset'
-        data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
+        data = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         data = fixOutliers(data);
         [~, position] = min(data);
         output = edfDat.Fixations.sttime(:,position);
     case 'meansacdist'
-        data = edfDat.Saccades.ampl(edfDat.Saccades.eye == i);
+        data = edfDat.Saccades.ampl(edfDat.Saccades.eye == i & edfDat.Saccades.sttime <= recEnd - recStart);
         % ampl = amplitude of saccade (ie distance)
         % there is also phi, which is direction in degrees (ie not rads)
         data = fixOutliers(data);
@@ -74,18 +79,18 @@ switch metricName
         output = mean(data);
     case 'positionMax'
         % This is probably useless
-        A = edfDat.Fixations.time(edfDat.Fixations.eye == i);
-        B = edfDat.Fixations.gavx(edfDat.Fixations.eye == i);
-        C = edfDat.Fixations.gavy(edfDat.Fixations.eye == i);
+        A = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
+        B = edfDat.Fixations.gavx(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
+        C = edfDat.Fixations.gavy(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         [~, colIdx] = max(A);
         valueInB = B(colIdx);
         valueInC = C(colIdx);
         output = [valueInB; valueInC];
     case 'positionMin'
         % This also seems useless
-        A = edfDat.Fixations.time(edfDat.Fixations.eye == i);
-        B = edfDat.Fixations.gavx(edfDat.Fixations.eye == i);
-        C = edfDat.Fixations.gavy(edfDat.Fixations.eye == i);
+        A = edfDat.Fixations.time(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
+        B = edfDat.Fixations.gavx(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
+        C = edfDat.Fixations.gavy(edfDat.Fixations.eye == i & edfDat.Fixations.sttime <= recEnd - recStart);
         [~, colIdx] = min(A);
         valueInB = B(colIdx);
         valueInC = C(colIdx);

--- a/Analysis/selectMetric.m
+++ b/Analysis/selectMetric.m
@@ -5,6 +5,7 @@ function output = selectMetric(edfDat, metricName, varargin)
 % Options are as follows:
 %   'fixation' - Total fixation time per trial
 %   'scaledfixation' - Percentage of video time spent fixating
+%   'duration' - Duration of the video (a QC metric)
 %   'meanfix' - Average fixation duration within a trial
 %   'medianfix' - Median fixation duration within a trial
 %   'maxfixOnset' - Onset time of the longest fixation
@@ -39,6 +40,10 @@ switch metricName
         % so just calculate it from start and end time instead.
 
         output = data / duration;
+    case 'duration'
+        numSamples = double(edfDat.Header.endtime - edfDat.Header.starttime);
+        sampleRate = double(edfDat.Header.rec.sample_rate);
+        output = numSamples / sampleRate;
     case 'meanfix'
         data = edfDat.Fixations.time(edfDat.Fixations.eye == i);
         data = fixOutliers(data);


### PR DESCRIPTION
We previously (incorrectly) considered eyetracking data covering the entire _trial_ duration, which includes drift check and RT, instead of just the _stimulus_ duration. This update addresses that issue by checking for markers indicating stimulus onset and offset, and ignoring any "Events" (e.g. fixations) that occur outside that timeframe.

Most of the changes were implemented via `selectMetric`, so any new metrics will need to copy the solution from the existing metrics I adjusted.