### PR TITLE
Hotfix10

### DIFF
--- a/Analysis/edfTranslate.m
+++ b/Analysis/edfTranslate.m
@@ -15,6 +15,7 @@ output = struct('Header', [], 'Samples', [], 'Events', []);
 events = struct2table(data.FEVENT);
 
 numRecs = length(data.RECORDINGS);
+fprintf(1, 'Separating data stream into %i trials...', numRecs/2);
 for i = 1:2:numRecs
     t = (i+1)/2; % index for output. i goes 1,3,5... but we want 1,2,3...
     % Get start and end time
@@ -103,7 +104,8 @@ for i = 1:2:numRecs
     output(t).Events.buttons = events.buttons(stevent:enevent)';
     output(t).Events.parsedby = events.parsedby(stevent:enevent)';
     output(t).Events.message = events.message(stevent:enevent)';
-
+    % Replace [] messages with '', so they are all still strings.
+    output(t).Events.message(cellfun(@isempty, output(t).Events.message)) = {''};
 end
-
+fprintf(1, 'Done.\n');
 end % function

--- a/Analysis/edfTranslate.m
+++ b/Analysis/edfTranslate.m
@@ -1,0 +1,109 @@
+function output = edfTranslate(data)
+% Convert the output of edfmex to look like the output of edfMexImport.
+% This means converting a 1x1 with 6 different 1x? structs into one 1xn.
+
+% Essentially what's happening is that the data is not yet split by trial:
+% it's all just one continuous stream of data.
+% So this function reads data from edfmex's RECORDINGS struct,
+% determines where the divisions between trials are (based on timestamps),
+% then splits the data in FSAMPLE and FEVENT into one row per trial.
+
+% init output var
+output = struct('Header', [], 'Samples', [], 'Events', []);
+
+% turn event struct into a table for easier manipulation
+events = struct2table(data.FEVENT);
+
+numRecs = length(data.RECORDINGS);
+for i = 1:2:numRecs
+    t = (i+1)/2; % index for output. i goes 1,3,5... but we want 1,2,3...
+    % Get start and end time
+    sttime = data.RECORDINGS(i).time;
+    entime = data.RECORDINGS(i+1).time;
+    % Find associated samples
+    stsample = find(data.FSAMPLE.time == sttime);
+    ensample = find(data.FSAMPLE.time <= entime, 1, 'last');
+    % Find associated events, bc different
+    stevent = find(strcmp(events.message, sprintf('TRIALID %i', t)));
+    enevent = find(strcmp(events.codestring, 'ENDSAMPLES'),t,'first');
+    enevent = enevent(end);
+    
+    % Fill in header info
+    output(t).Header.rec = data.RECORDINGS(t);
+    output(t).Header.starttime = events.sttime(stevent);
+    output(t).Header.endtime = events.sttime(enevent);
+    output(t).Header.duration = output(t).Header.endtime - output(t).Header.starttime;
+
+    % Grab samples based on detected indices
+    output(t).Samples.RealNumberOfSamples = length(stsample:ensample);
+    output(t).Samples.time = data.FSAMPLE.time(:,stsample:ensample);
+    output(t).Samples.px = data.FSAMPLE.px(:,stsample:ensample);
+    output(t).Samples.py = data.FSAMPLE.py(:,stsample:ensample);
+    output(t).Samples.hx = data.FSAMPLE.hx(:,stsample:ensample);
+    output(t).Samples.hy = data.FSAMPLE.hy(:,stsample:ensample);
+    output(t).Samples.pa = data.FSAMPLE.pa(:,stsample:ensample);
+    output(t).Samples.gx = data.FSAMPLE.gx(:,stsample:ensample);
+    output(t).Samples.gy = data.FSAMPLE.gy(:,stsample:ensample);
+    output(t).Samples.rx = data.FSAMPLE.rx(:,stsample:ensample);
+    output(t).Samples.ry = data.FSAMPLE.ry(:,stsample:ensample);
+    output(t).Samples.gxvel = data.FSAMPLE.gxvel(:,stsample:ensample);
+    output(t).Samples.gyvel = data.FSAMPLE.gyvel(:,stsample:ensample);
+    output(t).Samples.hxvel = data.FSAMPLE.hxvel(:,stsample:ensample);
+    output(t).Samples.hyvel = data.FSAMPLE.hyvel(:,stsample:ensample);
+    output(t).Samples.rxvel = data.FSAMPLE.rxvel(:,stsample:ensample);
+    output(t).Samples.ryvel = data.FSAMPLE.ryvel(:,stsample:ensample);
+    output(t).Samples.fgxvel = data.FSAMPLE.fgxvel(:,stsample:ensample);
+    output(t).Samples.fgyvel = data.FSAMPLE.fgyvel(:,stsample:ensample);
+    output(t).Samples.fhxvel = data.FSAMPLE.fhxvel(:,stsample:ensample);
+    output(t).Samples.fhyvel = data.FSAMPLE.fhyvel(:,stsample:ensample);
+    output(t).Samples.frxvel = data.FSAMPLE.frxvel(:,stsample:ensample);
+    output(t).Samples.fryvel = data.FSAMPLE.fryvel(:,stsample:ensample);
+    output(t).Samples.hdata = data.FSAMPLE.hdata(:,stsample:ensample);
+    output(t).Samples.flags = data.FSAMPLE.flags(:,stsample:ensample);
+    output(t).Samples.input = data.FSAMPLE.input(:,stsample:ensample);
+    output(t).Samples.buttons = data.FSAMPLE.buttons(:,stsample:ensample);
+    output(t).Samples.htype = data.FSAMPLE.htype(:,stsample:ensample);
+    output(t).Samples.errors = data.FSAMPLE.errors(:,stsample:ensample);
+
+    % Grab all the event data
+    % This is oriented vertically instead of horizontally,
+    % which will take some effort to get through.
+    output(t).Events.time = events.time(stevent:enevent)';
+    output(t).Events.type = events.type(stevent:enevent)';
+    output(t).Events.read = events.read(stevent:enevent)';
+    output(t).Events.eye = events.eye(stevent:enevent)';
+    output(t).Events.sttime = events.sttime(stevent:enevent)';
+    output(t).Events.entime = events.entime(stevent:enevent)';
+    output(t).Events.hstx = events.hstx(stevent:enevent)';
+    output(t).Events.hsty = events.hsty(stevent:enevent)';
+    output(t).Events.gstx = events.gstx(stevent:enevent)';
+    output(t).Events.gsty = events.gsty(stevent:enevent)';
+    output(t).Events.sta = events.sta(stevent:enevent)';
+    output(t).Events.henx = events.henx(stevent:enevent)';
+    output(t).Events.heny = events.heny(stevent:enevent)';
+    output(t).Events.genx = events.genx(stevent:enevent)';
+    output(t).Events.geny = events.geny(stevent:enevent)';
+    output(t).Events.ena = events.ena(stevent:enevent)';
+    output(t).Events.havx = events.havx(stevent:enevent)';
+    output(t).Events.havy = events.havy(stevent:enevent)';
+    output(t).Events.gavx = events.gavx(stevent:enevent)';
+    output(t).Events.gavy = events.gavy(stevent:enevent)';
+    output(t).Events.ava = events.ava(stevent:enevent)';
+    output(t).Events.avel = events.avel(stevent:enevent)';
+    output(t).Events.pvel = events.pvel(stevent:enevent)';
+    output(t).Events.svel = events.svel(stevent:enevent)';
+    output(t).Events.evel = events.evel(stevent:enevent)';
+    output(t).Events.supd_x = events.supd_x(stevent:enevent)';
+    output(t).Events.eupd_x = events.eupd_x(stevent:enevent)';
+    output(t).Events.supd_y = events.supd_y(stevent:enevent)';
+    output(t).Events.eupd_y = events.eupd_y(stevent:enevent)';
+    output(t).Events.status = events.status(stevent:enevent)';
+    output(t).Events.flags = events.flags(stevent:enevent)';
+    output(t).Events.input = events.input(stevent:enevent)';
+    output(t).Events.buttons = events.buttons(stevent:enevent)';
+    output(t).Events.parsedby = events.parsedby(stevent:enevent)';
+    output(t).Events.message = events.message(stevent:enevent)';
+
+end
+
+end % function

--- a/Analysis/osfImport.m
+++ b/Analysis/osfImport.m
@@ -26,10 +26,24 @@ try
     else
         fileLoc = pths.data;
     end
-    
-    
+
     addpath(pths.edf);
-    [Trials, Preamble] = edfImport([fileLoc filesep fileName], [1 1 1], '');
+
+    % Check for .mat file, in case bad subject (or just to be lazy)
+    fileName2 = [fileName(1:end-3) 'mat'];
+    fp = [fileLoc filesep fileName2];
+    if exist(fp, 'file')
+        % Import existing data
+        fprintf(1, 'Importing data from .mat file.\n');
+        Trials = importdata(fp);
+        if isfield(Trials, 'FILENAME')
+            % Convert to look like edfImport output
+            Trials = edfTranslate(Trials);
+        end
+    else
+        % Perform standard import via mex
+        [Trials, Preamble] = edfImport([fileLoc filesep fileName], [1 1 1], '');
+    end
     Trials = edfExtractInterestingEvents(Trials);
 
 catch ME


### PR DESCRIPTION
Adds functionality to read in .mat data instead of .edf, and also converts SR Research's edfmex output to match the edfMexImport format we've been using (i.e. separates trials).

This came up because we had one subject whose data would crash Matlab for some reason, so SR converted the file to a .mat for me and then I had to figure out how to get it back into the format my analysis pipeline expected. Seems to all be resolved now.