### PR TITLE
AQ revision

### DIFF
--- a/Analysis/analysis.m
+++ b/Analysis/analysis.m
@@ -143,11 +143,10 @@ if choice == 1
                 title(distTxt3);
                 xlim(yl3);
                 % Add lines indicating the expected distribution(s)
-                overlayAQ(gca);
+                % overlayAQ(gca); % skip this 
         if ~mwflag
             % Calculate correlations and generate some visualizations
             output = getCorrelations(data, metricName);
-            plotCorrelation(data, output, metricName);
         
             % Now Fischer z-transform your correlation coefficients
             zCorr = zscore(output(:,2));
@@ -164,19 +163,24 @@ if choice == 1
             fprintf(1, 'Correlation between %s and above correlation:\n', var3)
             fprintf(1, '\t\x03C1 = %0.2f\n', secondCorr);
             
-            % Histograms of the variables at play
-            figure();
-            subplot(1,2,1);
-                histogram(data.Eyetrack);
-                xlabel(var1);
-                title(distTxt);
-                xlim(yl);
-            subplot(1,2,2)
-                histogram(data.Response);
-                xlabel(var2);
-                title(distTxt2);
         end % if not MW data
     end % for each AQ subscale
+
+    if ~mwflag % avoid doing this inside the loop over AQ subscales
+        % Plot correlation of gaze and clarity, i.e. not considering AQ
+        plotCorrelation(data, output, metricName);
+        % Histograms of gaze and clarity
+        figure();
+        subplot(1,2,1);
+            histogram(data.Eyetrack);
+            xlabel(var1);
+            title(distTxt);
+            xlim(yl);
+        subplot(1,2,2)
+            histogram(data.Response);
+            xlabel(var2);
+            title(distTxt2);
+    end
 elseif choice == 2
     % Do a mean comparison across groups
     subList = unique(data.Subject);

--- a/Analysis/analysis.m
+++ b/Analysis/analysis.m
@@ -74,97 +74,109 @@ if choice == 1
         % TC_01 == MW_01. Compensate.
         aqTable.SubID = replace(aqTable.SubID, 'TC','MW');
     end
-    % Ensure they're sorted the same as the other data
-    for s = 1:numSubs
-        subID = subList{s};
-        aq(s) = aqTable.AQ(strcmp(subID, aqTable.SubID));
-    end
-    aq = aq'; % Rotate 90 deg so it's a column vector like zCorr below
+    for a = 1:3 % AQ subscales
+        % Loop over the three AQ subscales
+        % Ensure they're sorted the same as the other data
+        aq = zeros([numSubs, 1]); % preallocate as column
+        for s = 1:numSubs
+            subID = subList{s};
+            if a == 1
+                aq(s) = aqTable.SocialSkills(strcmp(subID, aqTable.SubID));
+                aqt = 'AQ1';
+            elseif a == 2
+                aq(s) = aqTable.Communication(strcmp(subID, aqTable.SubID));
+                aqt = 'AQ2';
+            elseif a == 3
+                aq(s) = aqTable.AttentionDetail(strcmp(subID, aqTable.SubID));
+                aqt = 'AQ3';
+            end
+        end
     
-
-    % First, directly correlate the metric with AQ
-    % i.e. do not correlate with the clarity rating
-    % Reduce data to an average value per subject,
-    % since there's only 1 AQ value per person
-    [var3, yl3, distTxt3] = getGraphLabel('AQ');
-
-    aqCol = [];
-    for s = 1:numSubs
-        subID = subList{s};
-        subset = strcmp(subID, data.Subject);
-        nrows = sum(subset);
-        aqCol = [aqCol; aq(s) * ones(nrows,1)];
-    end
-    output(1,1) = corr(aqCol, data.Eyetrack, 'Type', 'Pearson', 'rows', 'complete');
-    output(1,2) = corr(aqCol, data.Eyetrack, 'Type', 'Spearman', 'rows', 'complete');
-        
-        % Plot
-        figure();
-        scatter(aqCol, data.Eyetrack);
-            title(sprintf('Across %i subjects, strength of relationship \x03C1 = %0.2f', numSubs, output(1,2)));
-            xlabel(var3);
-            ylabel(var1);
-            ylim(yl);
-            xlim(yl3);
+        % First, directly correlate the metric with AQ
+        % i.e. do not correlate with the clarity rating
+        % Reduce data to an average value per subject,
+        % since there's only 1 AQ value per person
+        [var3, yl3, distTxt3] = getGraphLabel(aqt);
+    
+        aqCol = [];
+        for s = 1:numSubs
+            subID = subList{s};
+            subset = strcmp(subID, data.Subject);
+            nrows = sum(subset);
+            aqCol = [aqCol; aq(s) * ones(nrows,1)];
+        end
+        output = zeros([1,2]); % clear on each loop
+        output(1,1) = corr(aqCol, data.Eyetrack, 'Type', 'Pearson', 'rows', 'complete');
+        output(1,2) = corr(aqCol, data.Eyetrack, 'Type', 'Spearman', 'rows', 'complete');
             
-        % Report the correlation score
-        fprintf(1, '\n\nCorrelation between AQ and %s:\n', var1)
-        fprintf(1, '\tSpearman''s \x03C1 = %0.2f\n', output(1,2));
-        fprintf(1, '\tPearson''s r = %0.2f\n', output(1,1));
-
-        % Report secondary correlation
-        aq2rating(1) = corr(aqCol, data.Response, 'Type', 'Spearman', 'rows', 'complete');
-        aq2rating(2) = corr(aqCol, data.Response, 'Type', 'Pearson', 'rows', 'complete');
-        fprintf(1, '\n\nCorrelation between AQ and %s:\n', var2);
-        fprintf(1, '\tSpearman''s \x03C1 = %0.2f\n', aq2rating(1));
-        fprintf(1, '\tPearson''s r = %0.2f\n', aq2rating(2));
-
-        % Histograms
-        figure();
-        subplot(1,2,1);
-            histogram(data.Eyetrack);
-            xlabel(var1);
-            title(distTxt);
-            xlim(yl);
-        subplot(1,2,2)
-            histogram(aq, 'BinEdges', 0:5:50);
-            xlabel(var3);
-            title(distTxt3);
-            xlim([0 50]);
-            % Add lines indicating the expected distribution(s)
-            overlayAQ(gca);
-    if ~mwflag
-        % Calculate correlations and generate some visualizations
-        output = getCorrelations(data, metricName);
-        plotCorrelation(data, output, metricName);
+            % Plot
+            figure();
+            scatter(aqCol, data.Eyetrack);
+                title(sprintf('Across %i subjects, strength of relationship \x03C1 = %0.2f', numSubs, output(1,2)));
+                xlabel(var3);
+                ylabel(var1);
+                ylim(yl);
+                xlim(yl3);
+                
+            % Report the correlation score
+            fprintf(1, '\n\nCorrelation between %s and %s:\n', var3, var1)
+            fprintf(1, '\tSpearman''s \x03C1 = %0.2f\n', output(1,2));
+            fprintf(1, '\tPearson''s r = %0.2f\n', output(1,1));
     
-        % Now Fischer z-transform your correlation coefficients
-        zCorr = zscore(output(:,2));
+            % Report secondary correlation
+            aq2rating(1) = corr(aqCol, data.Response, 'Type', 'Spearman', 'rows', 'complete');
+            aq2rating(2) = corr(aqCol, data.Response, 'Type', 'Pearson', 'rows', 'complete');
+            fprintf(1, '\n\nCorrelation between %s and %s:\n', var3, var2);
+            fprintf(1, '\tSpearman''s \x03C1 = %0.2f\n', aq2rating(1));
+            fprintf(1, '\tPearson''s r = %0.2f\n', aq2rating(2));
     
-        % Plot and analyze relationship between AQ and current metric
-        secondCorr = corr(aq, zCorr, 'Type', 'Spearman', 'rows', 'complete');
-        figure();
-            scatter(aq, zCorr, 'filled');
-            xlabel(var3);
-            ylabel('Z-Transformed Spearman correlation');
-            title(sprintf('Impact of AQ on %s''s relation with %s\n\x03C1 = %0.2f', var1, var2, secondCorr));
-    
-        fprintf(1, 'Correlation between AQ and above correlation:\n')
-        fprintf(1, '\t\x03C1 = %0.2f\n', secondCorr);
+            % Histograms
+            figure();
+            subplot(1,2,1);
+                histogram(data.Eyetrack);
+                xlabel(var1);
+                title(distTxt);
+                xlim(yl);
+            subplot(1,2,2)
+                histogram(aq, 'BinEdges', 0:5:50);
+                xlabel(var3);
+                title(distTxt3);
+                xlim(yl3);
+                % Add lines indicating the expected distribution(s)
+                overlayAQ(gca);
+        if ~mwflag
+            % Calculate correlations and generate some visualizations
+            output = getCorrelations(data, metricName);
+            plotCorrelation(data, output, metricName);
         
-        % Histograms of the variables at play
-        figure();
-        subplot(1,2,1);
-            histogram(data.Eyetrack);
-            xlabel(var1);
-            title(distTxt);
-            xlim(yl);
-        subplot(1,2,2)
-            histogram(data.Response);
-            xlabel(var2);
-            title(distTxt2);
-    end
-    
+            % Now Fischer z-transform your correlation coefficients
+            zCorr = zscore(output(:,2));
+        
+            % Plot and analyze relationship between AQ and current metric
+            secondCorr = corr(aq, zCorr, 'Type', 'Spearman', 'rows', 'complete');
+            figure();
+                scatter(aq, zCorr, 'filled');
+                xlabel(var3);
+                ylabel('Z-Transformed Spearman correlation');
+                title(sprintf('Impact of %s on %s''s relation with %s\n\x03C1 = %0.2f', var3, var1, var2, secondCorr));
+                xlim(yl3);
+        
+            fprintf(1, 'Correlation between %s and above correlation:\n', var3)
+            fprintf(1, '\t\x03C1 = %0.2f\n', secondCorr);
+            
+            % Histograms of the variables at play
+            figure();
+            subplot(1,2,1);
+                histogram(data.Eyetrack);
+                xlabel(var1);
+                title(distTxt);
+                xlim(yl);
+            subplot(1,2,2)
+                histogram(data.Response);
+                xlabel(var2);
+                title(distTxt2);
+        end % if not MW data
+    end % for each AQ subscale
 elseif choice == 2
     % Do a mean comparison across groups
     subList = unique(data.Subject);

--- a/Analysis/defineAQ.m
+++ b/Analysis/defineAQ.m
@@ -6,22 +6,21 @@ function scoreAQ = defineAQ()
 scoreAQ = table();
 scoreAQ.Question(1:50) = 1:50;
 
-
+% Identify which questions are reverse-coded
 agrees = [2, 4, 5, 6, 7, 9, 12, 13, 16, 18, 19, 20, 21, 22,  23,  26,  33,  35,  39,  41,  42,  43,  45,  46];
 disagrees = [1, 3, 8, 10, 11, 14, 15, 17, 24,  25,  27,  28,  29,  30,  31,  32,  34,  36,  37,  38,  40,  44, 47, 48, 49, 50];
-socskill = [1,11,13,15,22,36,44,45, 47, 48];
-attSwitch = [2,4,10,16,25,32,34, 37,43,46];
-attDet = [5,6,9,12,19,23,28, 29,30,49];
-comm = [7,17,18,26,27,31,33, 35,38,39];
-imag = [3,8,14,20,21,24,40,41, 42,50];
+% Identify which questions belong to which subscale
+socskill = [1,10,11,13,15,17,22,26,34,38,44,46,47]; % 13 total
+comm = [20,27,31,35,36,39,45,48]; % 8 total
+attDet = [5,6,9,12,19,23,41]; % 7 total
+others = ~ismember(1:50, [attDet, comm, socskill]);
 
 scoreAQ.Valence(agrees) = {'Agree'};
 scoreAQ.Valence(disagrees) = {'Disagree'};
 
 scoreAQ.Subscale(socskill) = {'Social Skills'};
-scoreAQ.Subscale(attSwitch) = {'Attention Switching'};
-scoreAQ.Subscale(attDet) = {'Attention to Detail'};
 scoreAQ.Subscale(comm) = {'Communication'};
-scoreAQ.Subscale(imag) = {'Imagination'};
+scoreAQ.Subscale(attDet) = {'Attention to Detail'};
+scoreAQ.Subscale(others) = {'Unused'};
 
 end

--- a/Analysis/getAQ.m
+++ b/Analysis/getAQ.m
@@ -45,10 +45,13 @@ end
 
 % Step 3 - Tally subscales
 output.SocialSkills = sum(questions{:, strcmp(scoreAQ.Subscale, 'Social Skills')}, 2);
-output.AttentionSwitching = sum(questions{:, strcmp(scoreAQ.Subscale, 'Attention Switching')}, 2);
-output.AttentionDetail = sum(questions{:, strcmp(scoreAQ.Subscale, 'Attention to Detail')}, 2);
 output.Communication = sum(questions{:, strcmp(scoreAQ.Subscale, 'Communication')}, 2);
-output.Imagination = sum(questions{:, strcmp(scoreAQ.Subscale, 'Imagination')}, 2);
+output.AttentionDetail = sum(questions{:, strcmp(scoreAQ.Subscale, 'Attention to Detail')}, 2);
+
+% Re-calculate total AQ based on the subscales
+% But keep in mind that the English paper said total scores are useless,
+% because some subscales are anti-correlated...
+output.AQ = output.SocialSkills + output.Communication + output.AttentionDetail;
 
 warning('on', 'MATLAB:table:ModifiedAndSavedVarnames');
 warning('on', 'MATLAB:textio:io:UnableToGuessFormat');

--- a/Analysis/getAQ.m
+++ b/Analysis/getAQ.m
@@ -31,15 +31,13 @@ questions = data(:,idx);
 
 clear data % save memory?
 
-% Step 2 - Recode values of 1:4 to 0 or 1
+% Step 2 - Recode the reversed questions
 scoreAQ = defineAQ(); % Get 'answer key'
 for i = 1:50
     if strcmp(scoreAQ.Valence(i), 'Agree')
-        questions{questions{:,i} <= 2, i} = 1;
-        questions{questions{:,i} >= 3, i} = 0;
-    elseif strcmp(scoreAQ.Valence(i), 'Disagree')
-        questions{questions{:,i} <= 2, i} = 0;
-        questions{questions{:,i} >=3, i} = 1;
+        % On a scale of 1-4, if 1 means "strongly agree" and that's bad,
+        % then change that 1/4 to a 4/4, etc.
+        questions{:,i} = 5 - questions{:,i};
     end
 end
 
@@ -49,6 +47,7 @@ output.Communication = sum(questions{:, strcmp(scoreAQ.Subscale, 'Communication'
 output.AttentionDetail = sum(questions{:, strcmp(scoreAQ.Subscale, 'Attention to Detail')}, 2);
 
 % Re-calculate total AQ based on the subscales
+% Score range is now 28 to 112, not 0 to 50
 % But keep in mind that the English paper said total scores are useless,
 % because some subscales are anti-correlated...
 output.AQ = output.SocialSkills + output.Communication + output.AttentionDetail;

--- a/Analysis/getGraphLabel.m
+++ b/Analysis/getGraphLabel.m
@@ -9,6 +9,18 @@ function [txt, varargout] = getGraphLabel(metricName)
 % This should typically be used as the histogram's title
 
 switch metricName
+    case 'AQ1'
+        txt = 'Social Skills score';
+        yl = [13 52]; % 13 questions scored 1-4
+        dist = 'Expect a bimodal distribution';
+    case 'AQ2'
+        txt = 'Communication Skills score';
+        yl = [8 32]; % 8 questions scored 1-4
+        dist = 'Expect a bimodal distribution';
+    case 'AQ3'
+        txt = 'Attention to Detail score';
+        yl = [7 28]; % 7 questions scored 1-4
+        dist = 'Expect a bimodal distribution';
     case 'rawfix'
         txt = 'Fixation durations in ms';
         yl = 'tight';
@@ -61,10 +73,6 @@ switch metricName
         txt = 'Intersubject correlation with group mean';
         yl = [0 1.1]; % correlation bounded 0:1
         dist = 'Expect a normal distribution';
-    case 'AQ'
-        txt = 'Autism Quotient';
-        yl = [0 50]; % fixed score 0-50
-        dist = 'Expect a bimodal distribution';
     case 'response'
         txt = 'Understandability rating';
         yl = [0 6]; % fixed response limit 1-5


### PR DESCRIPTION
The AQ as originally defined by Baron-Cohen et al (2001) has come under scrutiny in the intervening years. A more recent review by English et al (2020) found that out of 10 alternative definitions, the most statistically valid was a 3-factor model using a subset of the original questions, as proposed by Russell-Smith et al (2011). Further, the questions should be scored using the 4-point Likert scale as posed instead of binarized into "autism-like or not" 1s and 0s. Finally, they suggest that the subscales should be interpreted individually, and not aggregated into a single "total AQ score". 

This update implements this new method of scoring the AQ, now reporting results for all three subscales individually.