### PR TITLE
Update plots re nuisance, rating

### DIFF
--- a/Analysis/getCorrelation2.m
+++ b/Analysis/getCorrelation2.m
@@ -2,10 +2,14 @@ function data = getCorrelation2(data, metricName)
 % Given a stack of data from e.g. getTCData,
 % calculate the correlation with the motion energy of each video.
 
-% A correlation is inappropriate because many subjects watch each video,
-% but there is only one motion value per video.
-% You're better off doing some sort of regression that factors in subject,
-% or maybe reporting the average correlation per subject like before.
+% Since there's one motion value per video, but multiple subjects,
+% you need to average the data somewhere.
+% The most appropriate method is to get the average DV per VIDEO,
+% then correlate that with motion.
+% We don't care about within-subject correlations:
+% why would we care if sub1 has r = .9 but sub2 has r = .2?
+% It's not about how sensitive each sub is to motion, but rather
+% whether the DV is sensitive to motion. Is motion a confound?
 
 subList = unique(data.Subject);
 numSubs = length(subList);
@@ -27,45 +31,49 @@ for v = 1:numVids
     % Also extract the average Eyetrack value for this video, for later
     avgE(v,1) = mean(data.Eyetrack(subset));
     mot(v,1) = sum(motion.MotionEnergy{v});
+    rat(v,1) = mean(data.Response(subset));
 end
 
 % Loop over subject to calculate independent correlation coefficients
 output = [];
-for s = 1:numSubs
-    subID = subList{s};
-    subset = strcmp(data.Subject, subID);
-    output(s,1) = corr(data.Eyetrack(subset), data.Motion(subset), 'Type', 'Pearson', 'rows', 'complete');
-    output(s,2) = corr(data.Eyetrack(subset), data.Motion(subset), 'Type', 'Spearman', 'rows', 'complete');
-end
+% for s = 1:numSubs
+%     subID = subList{s};
+%     subset = strcmp(data.Subject, subID);
+%     output(s,1) = corr(data.Eyetrack(subset), data.Motion(subset), 'Type', 'Pearson', 'rows', 'complete');
+%     output(s,2) = corr(data.Eyetrack(subset), data.Motion(subset), 'Type', 'Spearman', 'rows', 'complete');
+% end
 
 % Get the names of what you're correlating
 var1 = getGraphLabel(metricName);
 var2 = 'Video motion energy';
+var3 = getGraphLabel('response');
 
-% Analyze the distribution of correlation scores
-mu = mean(output(:,2));
-sigma = std(output(:,2));
+[output(1,1), pval1] = corr(avgE, mot, 'type', 'Pearson');
+[output(1,2), pval2] = corr(avgE, mot, 'type', 'Spearman');
+[output(1,3), pval3] = corr(rat, mot, 'type', 'Spearman');
 
 % Calculate p values by performing a t-test against 0
 % Use atanh() as a Fischer r-to-z transform 
-[~,pval1] = ttest(atanh(output(:,1))); % Pearson
-[~,pval2] = ttest(atanh(output(:,2))); % Spearman
+% [~,pval1] = ttest(atanh(output(:,1))); % Pearson
+% [~,pval2] = ttest(atanh(output(:,2))); % Spearman
 
 fprintf(1, '\n\nRESULTS:\n');
-fprintf(1, 'Average correlation between %s and %s:\n', var1, var2);
-fprintf(1, '\tSpearman''s \x0304\x03C1 = %0.2f (SD = %0.2f), p = %0.3f\n', mu, sigma, pval2);
-fprintf(1, '\tPearson''s \x0304r = %0.2f (SD = %0.2f), p = %0.3f\n', mean(output(:,1)), std(output(:,1)), pval1);
-fprintf(1, 'Average subject-level percent variance explained by this relationship:\n');
-fprintf(1, '\tr%c = %0.2f%%\n', 178, 100*mean(output(:,2) .^2));
+fprintf(1, 'Correlation between average %s and %s:\n', var1, var2);
+fprintf(1, '\tSpearman''s \x03C1 = %0.2f , p = %0.3f\n', output(1,2), pval2);
+fprintf(1, '\tPearson''s r = %0.2f , p = %0.3f\n', output(1,1), pval1);
+fprintf(1, 'Percent variance explained by this relationship:\n');
+fprintf(1, '\tr%c = %0.2f%%\n', 178, 100*(output(:,2) .^2));
+fprintf(1, 'Correlation between average %s and %s:\n', var3, var2);
+fprintf(1, '\tSpearman''s \x03C1 = %0.2f , p = %0.3f\n', output(1,3), pval3);
 fprintf(1, '\n');
 
 % Plots
-figure();
-    % Grouped scatterplot - separates by subject
-    % Admittedly hard to read when there's 30 subjects
-    gscatter(data.Motion, data.Eyetrack, data.Subject);
-    xlabel(var2); ylabel(var1);
-    title(sprintf('Average correlation = %0.2f', mu));
+% figure();
+%     % Grouped scatterplot - separates by subject
+%     % Admittedly hard to read when there's 30 subjects
+%     gscatter(data.Motion, data.Eyetrack, data.Subject);
+%     xlabel(var2); ylabel(var1);
+%     title(sprintf('Average correlation = %0.2f', mu));
 
 figure();
     % Raw scatterplot
@@ -73,16 +81,19 @@ figure();
     [c1, p1] = corr(data.Eyetrack, data.Motion);
     scatter(data.Motion, data.Eyetrack);
     xlabel(var2); ylabel(var1);
-    title(sprintf('Correlation = %0.2f, p = %0.4f', c1, p1));
+    title(sprintf('r = %0.2f, p = %0.4f', c1, p1));
 
 figure();
     % Scatterplot of averaged data
-    % Artificially increases correlation by throwing away variance
-    [c2, p2] = corr(mot, avgE);
+    % [c2, p2] = corr(mot, avgE); % already done
     scatter(mot, avgE);
     xlabel(var2);
     ylabel(sprintf('%s, averaged across subjects', var1));
-    title(sprintf('Correlation = %0.2f, p = %0.4f', c2, p2));
+    title(sprintf('r = %0.2f, p = %0.4f', output(1,1), pval1));
 
-% Try regression instead?
-% mdl = fitlme(data, 'Eyetrack ~ Motion + (1 | Subject)')
+figure();
+    % Scatterplot of rating data
+    scatter(mot, rat);
+    xlabel(var2);
+    ylabel(sprintf('%s, averaged across subjects', var3));
+    title(sprintf('\x03C1 = %0.2f, p = %0.4f', output(1,3), pval3));

--- a/Analysis/getCorrelation3.m
+++ b/Analysis/getCorrelation3.m
@@ -2,10 +2,14 @@ function data = getCorrelation3(data, metricName)
 % Given a stack of data from e.g. getTCData,
 % insert the interactivity score of each video, and get a correlation.
 
-% A correlation is inappropriate because many subjects watch each video,
+% A correlation is only appropriate for getting a main effect
+% because many subjects watch each video,
 % but there is only one interactivity value per video.
-% You may be better off doing a regression that stratifies by subject,
-% or maybe reporting the average correlation per subject like before.
+% If you want to see whether individual subjects are more sensitive to interactivity than others,
+% you may be better off doing a regression that stratifies by subject,
+% or maybe correlating the average correlation per subject with AQ.
+% But the point of this function is just to see if interactivity is 
+% interfering with the DV at all.
 
 subList = unique(data.Subject);
 numSubs = length(subList);
@@ -28,37 +32,44 @@ for v = 1:numVids
     % Also extract the average Eyetrack value for this video, for later
     avgE(v,1) = mean(data.Eyetrack(subset));
     intr(v,1) = intScore.Interactivity(v);
+    rat(v,1) = mean(data.Response(subset));
 end
 
 % Loop over subject to calculate independent correlation coefficients
 output = [];
-p = [];
-for s = 1:numSubs
-    subID = subList{s};
-    subset = strcmp(data.Subject, subID);
-    [output(s,1), p(s,1)] = corr(data.Eyetrack(subset), data.Interactivity(subset), 'Type', 'Pearson', 'rows', 'complete');
-    [output(s,2), p(s,2)] = corr(data.Eyetrack(subset), data.Interactivity(subset), 'Type', 'Spearman', 'rows', 'complete');
-end
+% p = [];
+% for s = 1:numSubs
+%     subID = subList{s};
+%     subset = strcmp(data.Subject, subID);
+%     [output(s,1), p(s,1)] = corr(data.Eyetrack(subset), data.Interactivity(subset), 'Type', 'Pearson', 'rows', 'complete');
+%     [output(s,2), p(s,2)] = corr(data.Eyetrack(subset), data.Interactivity(subset), 'Type', 'Spearman', 'rows', 'complete');
+% end
 
 % Get the names of what you're correlating
 var1 = getGraphLabel(metricName);
 var2 = 'Social Interactivity Level';
+var3 = getGraphLabel('response');
 
 % Analyze the distribution of correlation scores
-mu = mean(output(:,2));
-sigma = std(output(:,2));
+% mu = mean(output(:,2));
+% sigma = std(output(:,2));
+[output(1,1), pval1] = corr(avgE, intr, 'type', 'Pearson');
+[output(1,2), pval2] = corr(avgE, intr, 'type', 'Spearman');
+[output(1,3), pval3] = corr(rat, intr, 'type', 'Spearman');
 
 % Calculate p values by performing a t-test against 0
 % Use atanh() as a Fischer r-to-z transform 
-[~,pval1] = ttest(atanh(output(:,1))); % Pearson
-[~,pval2] = ttest(atanh(output(:,2))); % Spearman
+% [~,pval1] = ttest(atanh(output(:,1))); % Pearson
+% [~,pval2] = ttest(atanh(output(:,2))); % Spearman
 
 fprintf(1, '\n\nRESULTS:\n');
-fprintf(1, 'Average correlation between %s and %s:\n', var1, var2);
-fprintf(1, '\tSpearman''s \x0304\x03C1 = %0.2f (SD = %0.2f), p = %0.3f\n', mu, sigma, pval2);
-fprintf(1, '\tPearson''s \x0304r = %0.2f (SD = %0.2f), p = %0.3f\n', mean(output(:,1)), std(output(:,1)), pval1);
-fprintf(1, 'Average subject-level percent variance explained by this relationship:\n');
-fprintf(1, '\tr%c = %0.2f%%\n', 178, 100*mean(output(:,2) .^2));
+fprintf(1, 'Correlation between average %s and %s:\n', var1, var2);
+fprintf(1, '\tSpearman''s \x03C1 = %0.2f , p = %0.3f\n', output(1,2), pval2);
+fprintf(1, '\tPearson''s r = %0.2f , p = %0.3f\n', output(1,1), pval1);
+fprintf(1, 'Percent variance explained by this relationship:\n');
+fprintf(1, '\tr%c = %0.2f%%\n', 178, 100*(output(:,2) .^2));
+fprintf(1, 'Correlation between average %s and %s:\n', var3, var2);
+fprintf(1, '\tSpearman''s \x03C1 = %0.2f , p = %0.3f\n', output(1,3), pval3);
 fprintf(1, '\n');
 
 % Plots
@@ -79,5 +90,9 @@ figure();
     ylabel(sprintf('%s, averaged across subjects', var1));
     title(sprintf('Correlation = %0.2f, p = %0.4f', c2, p2));
 
-% Try regression instead?
-% mdl = fitlme(data, 'Eyetrack ~ Interactivity + (1 | Subject)')
+figure();
+    % Scatterplot of rating data
+    scatter(intr, rat);
+    xlabel(var2);
+    ylabel(sprintf('%s, averaged across subjects', var3));
+    title(sprintf('\x03C1 = %0.2f, p = %0.4f', output(1,3), pval3));

--- a/Analysis/getCorrelations.m
+++ b/Analysis/getCorrelations.m
@@ -11,6 +11,9 @@ for s = 1:numSubs
     output(s,2) = corr(data.Response(subset), data.Eyetrack(subset), 'Type', 'Spearman', 'rows', 'complete');
 end
 
+% Also look at the overall correlation, since these are both DVs
+[c1, p1] = corr(data.Response, data.Eyetrack, 'type', 'Spearman', 'rows', 'complete');
+
 % Get the names of what you're correlating
 var1 = getGraphLabel(metricName);
 var2 = 'Understandability rating';
@@ -25,6 +28,8 @@ sigma = std(output(:,2));
 [~,pval2] = ttest(atanh(output(:,2))); % Spearman
 
 fprintf(1, '\n\nRESULTS:\n');
+fprintf(1, 'Overall correlation between %s and %s:\n', var1, var2);
+fprintf(1, '\tSpearman''s \x03C1 = %0.2f , p = %0.3f\n', c1, p1);
 fprintf(1, 'Average correlation between %s and %s:\n', var1, var2);
 fprintf(1, '\tSpearman''s \x0304\x03C1 = %0.2f (SD = %0.2f), p = %0.3f\n', mu, sigma, pval2);
 fprintf(1, '\tPearson''s \x0304r = %0.2f (SD = %0.2f), p = %0.3f\n', mean(output(:,1)), std(output(:,1)), pval1);

--- a/Analysis/plotItemwise.m
+++ b/Analysis/plotItemwise.m
@@ -45,10 +45,10 @@ tit = 'Videos sorted by duration, variance is across subjects';
 
 % Also calculate a correlation between metric and video duration
 % c = corr(plotData.Eyetrack, durCol', 'rows', 'complete');
-c = corr(eyeCol', d', 'rows', 'complete');
+[c,p1] = corr(eyeCol', d', 'rows', 'complete');
 % c2 = corr(plotData.Response, durCol', 'rows', 'complete');
 if ~mwflag
-    c2 = corr(ratCol', d', 'rows', 'complete', 'Type', 'Spearman');
+    [c2,p2] = corr(ratCol', d', 'rows', 'complete', 'Type', 'Spearman');
 end
 
 % Now make the plot
@@ -56,21 +56,40 @@ figure();
     boxplot(plotData.Eyetrack, plotData.StimName, 'GroupOrder', plotOrder);
     ylim(yl);
     ylabel(axistxt);
-    title(sprintf([tit '\nPearson''s r = %0.2f'],c));
+    title(sprintf([tit '\nPearson''s r = %0.2f, p = %0.4f'],c, p1));
     hold on
         scatter(1:numStims, eyeCol(o), "filled", "MarkerFaceColor", "#D95319");
     hold off
 
-% Make another for ratings
+    
 if ~mwflag
+    % Do it again as a scatterplot, so the x axis isn't artificially spaced
+    % Skip if MW bc all those videos are the same length
+    figure();
+        scatter(d(o), eyeCol(o), "filled");
+        ylim(yl);
+        ylabel(axistxt);
+        title(sprintf('Pearson''s r = %0.2f',c));
+        xlabel('Video Duration (sec)');
+        xlim([0 30]);
+
+    % Make another for ratings
     [ax2, yl2] = getGraphLabel('response');
     figure();
         boxplot(plotData.Response, plotData.StimName, 'GroupOrder', plotOrder);
         ylim(yl2);
         yticks(yl2(1)+1 : yl2(2) - 1); % 1:5
         ylabel(ax2);
-        title(sprintf([tit '\nSpearman''s rho = %0.2f'],c2));
+        title(sprintf([tit '\nSpearman''s \x03C1 = %0.2f'],c2));
         hold on
         scatter(1:length(stimList), ratCol(o), "filled", "MarkerFaceColor", "#D95319");
         hold off
+    % And again as a scatterplot, so the x axis isn't artificially spaced
+    figure();
+        scatter(d(o), ratCol(o), "filled");
+        ylim(yl2);
+        ylabel(['Average', ax2]);
+        title(sprintf('Spearman''s \x03C1 = %0.2f, p = %0.4f',c2,p2));
+        xlabel('Video Duration (sec)');
+        xlim([0 30]);
 end


### PR DESCRIPTION
Compares the nuisance variables like motion energy and duration to ratings to see if they are affected. Adds scatterplots of video duration against other variables instead of boxplots per video, to more realistically depict the trendlines.