### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 /beh/*.tsv
 /beh/pilot/
 /ExpOutputs/TCoutput/*.mat
+/data/derivatives
 /Analysis/allData.mat
 /Analysis/motionMaps/
 /Analysis/Results/

--- a/Analysis/BoxplotMW.m
+++ b/Analysis/BoxplotMW.m
@@ -17,7 +17,7 @@ nRows = ceil(numSubs/numPerRow);
 
 [axistxt, ylimvec] = getGraphLabel(metricName); % variable axis label text
 %% Split by condition
-close all
+% close all
 for i = 1:numConds
     thisCond = conds{i};
     figure();

--- a/Analysis/analysis.m
+++ b/Analysis/analysis.m
@@ -226,6 +226,7 @@ if choice == 1 % Correlation analysis
                 ylabel('Within-Subject Spearman correlation');
                 title(sprintf('Impact of %s on %s''s relation with %s\n\x03C1 = %0.2f, p = %0.4f', var3, var1, var2, secondCorr, secondP));
                 xlim(yl3);
+                ylim([-1 1]);
         
             fprintf(1, 'Correlation between %s and (within-subject correlation between %s and %s):\n', var3, var1, var2)
             fprintf(1, '\t\x03C1 = %0.2f, p = %0.4f\n', secondCorr, secondP);

--- a/Analysis/censorBlinks.m
+++ b/Analysis/censorBlinks.m
@@ -1,4 +1,4 @@
-function output = censorBlinks(output, edfDat)
+function [output, bs] = censorBlinks(output, edfDat)
 % Reject blink data and interpolate replacement values
 % But the default blink detection is slightly too conservative,
 % so pad the given values to catch on/off artifacts
@@ -15,5 +15,13 @@ if isfield(edfDat, 'Blinks') && ~isempty(edfDat.Blinks)
     bs = ismember(gazeTimes, blinkDurs); % blink samples
     % Now interpolate the values for bs based on everything else
     output(:,bs) = interp1(gazeTimes(~bs), output(~bs), gazeTimes(bs), 'makima');
+
+    % but don't output the number with the buffer
+
+else
+    % 'output' is the input, so don't need to define it
+    % but if no blinks were found, return an empty vector
+    bs = [];
 end
+
 end

--- a/Analysis/getMWData.m
+++ b/Analysis/getMWData.m
@@ -58,7 +58,9 @@ for subject = 1:numSubs
     fprintf(1, 'Reading from %s...\n', edfList(subject).name);
     
     subID = erase(edfList(subject).name, '.edf');
-    Trials = osfImport(edfList(subject).name);
+    edfName = edfList(subject).name;
+    fpath = fullfile(outputPath, edfName);
+    Trials = osfImport(fpath);
     
     eyetrack = []; % init per sub
     badList = [];

--- a/Analysis/getTCData.m
+++ b/Analysis/getTCData.m
@@ -7,7 +7,7 @@ function data = getTCData(metricName, taskFlag, subList)
     % Find the location of our data
     addpath('..'); % Allow specifyPaths to work
     pths = specifyPaths('..');
-    if nargin > 1
+    if nargin < 2
         % Default to the original method
         taskFlag = 'tri';
     end
@@ -83,7 +83,8 @@ function data = getTCData(metricName, taskFlag, subList)
         
         % Get eyetracking data
         fprintf(1, '%s: ', subID);
-        edf = osfImport(edfName);
+        fpath = fullfile(outputPath, edfName);
+        edf = osfImport(fpath);
         eyetrack = []; % init per sub
         badList = [];
         

--- a/Analysis/getTCData.m
+++ b/Analysis/getTCData.m
@@ -1,15 +1,32 @@
-function data = getTCData(metricName, subList)
+function data = getTCData(metricName, taskFlag, subList)
+% Returns a table of data for all subjects with eyetracking, trial num, etc
+% Input 1: metric name, as used in selectMetric. e.g. 'tot', 'blinkrate'
+% Input 2: task type. Options are 'nar' for narrative or 'tri' for all 100
+% Input 3: list of subjects
+
     % Find the location of our data
     addpath('..'); % Allow specifyPaths to work
     pths = specifyPaths('..');
-    outputPath = pths.TCdat;
+    if nargin > 1
+        % Default to the original method
+        taskFlag = 'tri';
+    end
+    % Check which task you want data for - original TriCOPA, or narrative
+    if strcmp(taskFlag, 'nar')
+        outputPath = pths.NARdat;
+    elseif strcmp(taskFlag, 'tri')
+        outputPath = pths.TCdat;
+    else
+        error('Incorrect task flag! Options are ''tri'' or ''nar''');
+    end
+
     fileList = dir(outputPath);
         % String-insensitive compare, in case file extension is uppercase
         fnames = {fileList.name};
         subset = cellfun(@(x)endsWith(lower(x), '.edf'), fnames, 'UniformOutput', false);
         subset = cell2mat(subset);
         edfList = fileList(subset); clear fileList
-    if nargin > 1
+    if nargin > 2
         % subset edfList to just the subjects asked for
         subIDs = arrayfun(@(x) sprintf('TC_%02.f', x), subList, 'UniformOutput', false);
         subset = contains({edfList.name}, subIDs);

--- a/Analysis/osfImport.m
+++ b/Analysis/osfImport.m
@@ -19,22 +19,26 @@ try
     %%
     if contains(fileName,'MW')
         fileLoc = pths.MWdat;
+        matLoc = pths.MWmat;
     elseif contains(fileName,'TC')
         fileLoc = pths.TCdat;
+        matLoc = pths.TCmat;
     elseif contains(fileName,'fix')
         fileLoc = pths.fixdat;
+        matLoc = pths.fixmat;
     else
         fileLoc = pths.data;
+        matLoc = pths.data;
     end
 
     addpath(pths.edf);
 
     % Check for .mat file, in case bad subject (or just to be lazy)
     fileName2 = [fileName(1:end-3) 'mat'];
-    fp = [fileLoc filesep fileName2];
+    fp = fullfile(matLoc, fileName2);
     if exist(fp, 'file')
         % Import existing data
-        fprintf(1, 'Importing data from .mat file.\n');
+        fprintf(1, 'Importing data from %s\n', fp);
         Trials = importdata(fp);
         if isfield(Trials, 'FILENAME')
             % Convert to look like edfImport output
@@ -43,6 +47,9 @@ try
     else
         % Perform standard import via mex
         [Trials, Preamble] = edfImport([fileLoc filesep fileName], [1 1 1], '');
+        % Export to mat file, to save time on future imports
+        save(fp, 'Trials');
+        fprintf(1, 'Data exported to %s\n', fp);
     end
     Trials = edfExtractInterestingEvents(Trials);
 

--- a/Analysis/osfImport.m
+++ b/Analysis/osfImport.m
@@ -1,8 +1,9 @@
 function [Trials, Preamble] = osfImport(fileName)
-% Import edf file to matlab using OSF edfImport() and edfExtractInterestingEvents() 
-% Input 1 is expected to be JUST the filename, i.e. no path attached
-% This function dynamically find a path to the file based on its prefix
-% Direct questions to A.E.
+% Import an edf file to matlab using OSF edfImport() and edfExtractInterestingEvents() 
+% Input 1 is expected to contain the entire path
+% This function analyzes that path to determine if the data is TC, MW, etc.
+% If data was saved to .mat (in another folder), will load that instead.
+
 addpath('..'); % to allow specifyPaths to run
 pths = specifyPaths('..');
 try
@@ -17,13 +18,16 @@ try
     end
     
     %%
-    if contains(fileName,'MW')
+    if contains(fileName,['source' filesep 'MW'])
         fileLoc = pths.MWdat;
         matLoc = pths.MWmat;
-    elseif contains(fileName,'TC')
+    elseif contains(fileName,['source' filesep 'TC'])
         fileLoc = pths.TCdat;
         matLoc = pths.TCmat;
-    elseif contains(fileName,'fix')
+    elseif contains(fileName, ['source' filesep 'NAR'])
+        fileLoc = pths.NARdat;
+        matLoc = pths.NARmat;
+    elseif contains(fileName,['source' filesep 'fixation_checks'])
         fileLoc = pths.fixdat;
         matLoc = pths.fixmat;
     else
@@ -34,7 +38,9 @@ try
     addpath(pths.edf);
 
     % Check for .mat file, in case bad subject (or just to be lazy)
-    fileName2 = [fileName(1:end-3) 'mat'];
+    [~,fileName2] = fileparts(fileName);
+    % fileName2 = [fileName2(1:end-3) 'mat'];
+    fileName2 = [fileName2 '.mat'];
     fp = fullfile(matLoc, fileName2);
     if exist(fp, 'file')
         % Import existing data
@@ -46,7 +52,7 @@ try
         end
     else
         % Perform standard import via mex
-        [Trials, Preamble] = edfImport([fileLoc filesep fileName], [1 1 1], '');
+        [Trials, Preamble] = edfImport(fileName, [1 1 1], '');
         % Export to mat file, to save time on future imports
         save(fp, 'Trials');
         fprintf(1, 'Data exported to %s\n', fp);

--- a/Analysis/plotCorrelation.m
+++ b/Analysis/plotCorrelation.m
@@ -21,11 +21,11 @@ nRows = ceil(numSubs/numPerRow);
 % Open figures
 fig1 = figure();
     if ok
-        tiledlayout(nRows, 10);
+        tiledlayout(nRows, numPerRow);
     end
 fig2 = figure();
     if ok
-        tiledlayout(nRows, 10);
+        tiledlayout(nRows, numPerRow);
     end
 % Get axis titles
 [var1, yl] = getGraphLabel(metricName);

--- a/Analysis/rankAQperVid.m
+++ b/Analysis/rankAQperVid.m
@@ -1,4 +1,4 @@
-function [x, vidList] = rankAQperVid(data)
+function [output, vidList] = rankAQperVid(data)
 % Given a stack of eyetracking data, rank each AQ subscale per video
 % Calculate an LME per video and extract the Coefficients structure
 % Output is a 4*n*100 matrix stacking them in the 3rd dimension

--- a/Analysis/selectMetric.m
+++ b/Analysis/selectMetric.m
@@ -195,6 +195,20 @@ switch metricName
         % Get the data
         output = getHeatmap(xdat, ydat, scDim, binRes);
         
+    case 'interp'
+        % A QC metric to see what proportion of gaze gets interpolated
+        % Since X and Y coordinates are interpolated separately,
+        % we take the intexing vector of both, sum them, then average.
+
+        % Get the XY timeseries and convert from uint32 for precision
+        xdat = double(edfDat.Samples.gx(i+1,:));
+        ydat = double(edfDat.Samples.gy(i+1,:));
+        % Interpolate over blinks
+        [xdat, blinkx] = censorBlinks(xdat, edfDat);
+        [~, blinky] = censorBlinks(ydat, edfDat);
+        % Calculate the proportion of gaze samples that were interpolated.
+        output = sum(blinkx | blinky) / length(xdat);
+
     case 'gaze'
         % This is a 4*n matrix covering n timepoints:
         % The first 2 rows are X-Y coordinate pairs

--- a/specifyPaths.m
+++ b/specifyPaths.m
@@ -17,10 +17,15 @@ else
 end
 
 pths.analysis = fullfile(pths.base, 'Analysis');
-pths.data = fullfile(pths.base, 'ExpOutputs'); % but rename to 'data'
-    pths.MWdat = fullfile(pths.data, 'MWoutput');
-    pths.TCdat = fullfile(pths.data, 'TCoutput');
+pths.data = fullfile(pths.base, 'data', 'source');
+    pths.MWdat = fullfile(pths.data, 'MW');
+    pths.TCdat = fullfile(pths.data, 'TC');
+    pths.NARdat = fullfile(pths.data, 'NAR');
     pths.fixdat = fullfile(pths.data, 'fixation_checks');
+pths.matdata = fullfile(pths.base, 'data', 'derivatives');
+    pths.MWmat = fullfile(pths.matdata, 'MW');
+    pths.TCmat = fullfile(pths.matdata, 'TC');
+    pths.NARmat = fullfile(pths.matdata, 'NAR');
 
 pths.stimuli = fullfile(pths.base, 'stims');
     pths.MWstim = fullfile(pths.stimuli, 'MartinWeisberg');


### PR DESCRIPTION
Reworks some of the data import functions in order to allow for different paradigms using a given stimulus set (e.g. an experiment using all 100 TriCOPA videos, or an experiment using just 26 but also asking for real-time narration).
The old `ExpOutputs` folder has been renamed `data` for clarity, with `source` and `derivatives` subfolders.

`getTCData` and `getMWData` will now export .EDF data to a .MAT file in the `derivatives` folder, and will preferentially load those .MAT files if they exist.

Also includes some minor changes (e.g. figure axis scaling) 